### PR TITLE
Exclude echo_chamber from ALL target

### DIFF
--- a/test/echo_chamber/CMakeLists.txt
+++ b/test/echo_chamber/CMakeLists.txt
@@ -23,5 +23,5 @@ include_directories(
 
 file(GLOB sources "${CMAKE_SOURCE_DIR}/test/echo_chamber/*.cc")
 
-add_executable(echo_chamber ${sources})
+add_executable(echo_chamber EXCLUDE_FROM_ALL ${sources})
 target_link_libraries(echo_chamber ${Boost_LIBRARIES} np1sec)


### PR DESCRIPTION
To avoid adding Boost as a dependency for the core of the project.

This is the "quick" of the two possible solutions. The other one would be to get rid of Boost.Asio in favor of "simple" queues.

Pros of this "quick" solution:
  * we already have it (need not be a permanent solution though)
  * possible to extend the tests to work between processes (using TCP connections between clients and the server)
Cons:
  * One needs to build echo_chamber explicitly with `make echo_chamber`
  * Not everyone has to have (be willing to download) Boost.Asio