### PR TITLE
Add explicit header <functional> otherwise compilation fails on some

### DIFF
--- a/src/room.h
+++ b/src/room.h
@@ -24,6 +24,7 @@
 #include "message.h"
 #include "timer.h"
 
+#include <functional>
 #include <deque>
 #include <map>
 #include <set>


### PR DESCRIPTION
system (tested on up-to-date ArchLinux) with "error: 'function' in
namespace 'std' does not name a template type"

Signed-off-by: KheOps <kheops@ceops.eu>